### PR TITLE
Change $create_order to $update_order

### DIFF
--- a/src/inc/sift-object-validator.php
+++ b/src/inc/sift-object-validator.php
@@ -1331,14 +1331,14 @@ class SiftObjectValidator {
 	}
 
 	/**
-	 * Validate a $create_order event.
+	 * Validate a $create_order or $update_order event.
 	 *
 	 * @param array $data The event to validate.
 	 *
 	 * @return mixed
 	 * @throws \Exception If the event is invalid.
 	 */
-	public static function validate_create_order( $data ) {
+	public static function validate_create_or_update_order( $data ) {
 		$validator_map = array(
 			'$user_id'                   => array( __CLASS__, 'validate_id' ),
 			'$session_id'                => 'is_string',
@@ -1369,12 +1369,12 @@ class SiftObjectValidator {
 		);
 		try {
 			static::validate( $data, $validator_map );
-			// required field: $user_id
-			if ( empty( $data['$user_id'] ) ) {
-				throw new \Exception( 'missing $user_id' );
+			// required field: $session_id if no $user_id provided.
+			if ( ! isset( $data['$user_id'] ) && empty( $data['$session_id'] ) ) {
+				throw new \Exception( 'missing $session_id' );
 			}
 		} catch ( \Exception $e ) {
-			throw new \Exception( 'Failed to validate $create_order event: ' . esc_html( $e->getMessage() ) );
+			throw new \Exception( 'Failed to validate order event: ' . esc_html( $e->getMessage() ) );
 		}
 		return true;
 	}

--- a/src/inc/woocommerce-actions.php
+++ b/src/inc/woocommerce-actions.php
@@ -39,7 +39,6 @@ class Events {
 		add_action( 'woocommerce_remove_cart_item', array( static::class, 'remove_from_cart' ), 100, 2 );
 
 		add_action( 'woocommerce_checkout_order_processed', array( static::class, 'create_order' ), 100, 3 );
-		add_action( 'woocommerce_new_order', array( static::class, 'add_session_info' ), 100 );
 		add_action( 'post_updated', array( static::class, 'update_order' ), 100 );
 
 		/**
@@ -521,17 +520,6 @@ class Events {
 			$properties
 		);
 	}
-
-	/**
-	 * Adds session info to the order.
-	 *
-	 * Unsure if necessary?  Was in prior plugin. -- George
-	 *
-	 * @param string $order_id ID of the order.
-	 *
-	 * @return void
-	 */
-	public static function add_session_info( string $order_id ) {}
 
 	/**
 	 * Log error for unsupported status changes.

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -111,6 +111,7 @@ abstract class EventTest extends WP_UnitTestCase {
 		parent::set_up();
 		Events::$to_send = [];
 		static::$errors  = [];
+		wc_clear_notices();
 	}
 
 	/**

--- a/tests/SiftApi/Validate_CreateOrUpdateOrder_Test.php
+++ b/tests/SiftApi/Validate_CreateOrUpdateOrder_Test.php
@@ -12,11 +12,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once 'SiftObjectValidatorTest.php';
 
-class Validate_CreateOrder_Test extends SiftObjectValidatorTest {
+class Validate_CreateOrUpdateOrder_Test extends SiftObjectValidatorTest {
 	protected static ?string $fixture_name = 'create-order.json';
 
 	protected static function validator( $data ) {
-		return SiftObjectValidator::validate_create_order( $data );
+		return SiftObjectValidator::validate_create_or_update_order( $data );
+	}
+
+	public function test_session_id_required_if_no_user_id_set() {
+		static::assert_invalid_argument_exception(
+			static::modify_data( [ '$user_id' => null, '$session_id' => null ] ),
+			'missing $session_id'
+		);
 	}
 
 	public function test_app_browser_set() {

--- a/tests/UpdateOrderEventTest.php
+++ b/tests/UpdateOrderEventTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class CreateOrderEventTest
+ * Class UpdateOrderEventTest
  *
  * @package Sift_Decisions
  */
@@ -14,13 +14,13 @@ use WPCOMSpecialProjects\SiftDecisions\WooCommerce_Actions\Events;
 /**
  * Test case.
  */
-class CreateOrderEventTest extends EventTest {
+class UpdateOrderEventTest extends EventTest {
 	/**
 	 * Test that the $create_order event is triggered.
 	 *
 	 * @return void
 	 */
-	public function test_create_account() {
+	public function test_create_order() {
 		// Arrange
 		// - create a user and log them in
 		$user_id = $this->factory()->user->create();
@@ -37,7 +37,7 @@ class CreateOrderEventTest extends EventTest {
 
 		// Assert
 		static::fail_on_error_logged();
-		static::assertCreateOrderEventTriggered();
+		static::assertUpdateOrderEventTriggered();
 
 		// Clean up
 		wp_delete_user( $user_id );
@@ -48,8 +48,8 @@ class CreateOrderEventTest extends EventTest {
 	 *
 	 * @return void
 	 */
-	public static function assertCreateOrderEventTriggered() {
-		$events = static::filter_events( [ 'event' => '$create_order' ] );
-		static::assertGreaterThanOrEqual( 1, count( $events ), 'No $create_order event found' );
+	public static function assertUpdateOrderEventTriggered() {
+		$events = static::filter_events( [ 'event' => '$update_order' ] );
+		static::assertGreaterThanOrEqual( 1, count( $events ), 'No $update_order event found' );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `$update_order` is a better event to support (and `$create_order` is not needed).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* tests included.

Mentions https://github.com/Automattic/gold/issues/502
